### PR TITLE
feat: Add ingress configuration with environment variable support

### DIFF
--- a/.github/workflows/deploy-k8s.yml
+++ b/.github/workflows/deploy-k8s.yml
@@ -18,6 +18,7 @@ env:
   GKE_CLUSTER: ${{ secrets.GKE_CLUSTER }}
   GKE_ZONE: ${{ secrets.GKE_ZONE }}
   PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  INGRESS_HOST: ${{ secrets.INGRESS_HOST || 'mcp.example.com' }}
 
 jobs:
   deploy:
@@ -58,6 +59,10 @@ jobs:
     - name: Deploy to GKE
       run: |
         cd k8s
+        # Replace INGRESS_HOST placeholder with actual value
+        if [ -f ingress.yaml ]; then
+          sed -i "s/INGRESS_HOST/$INGRESS_HOST/g" ingress.yaml
+        fi
         kubectl apply -k .
 
     - name: Verify deployment

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,41 @@
+# Kubernetes Deployment Configuration
+
+This directory contains Kubernetes manifests for deploying the Brave Search MCP server to Google Kubernetes Engine (GKE).
+
+## Configuration
+
+### Required Secrets
+
+The following secrets need to be configured in your GitHub repository:
+
+- `GKE_CLUSTER`: Name of your GKE cluster
+- `GKE_ZONE`: GCP zone where your cluster is located
+- `GCP_PROJECT_ID`: Your GCP project ID
+- `WIF_PROVIDER`: Workload Identity Federation provider
+- `BRAVE_API_KEY`: Your Brave Search API key
+- `ALLOWED_ORIGINS`: Allowed origins for CORS
+- `INGRESS_HOST`: The domain name for your ingress (e.g., `mcp.example.com`)
+
+### Ingress Configuration
+
+The ingress configuration uses a placeholder `INGRESS_HOST` that gets replaced during deployment with the value from GitHub secrets. This allows the configuration to remain generic and reusable across different environments.
+
+## Deployment
+
+Deployment is automated through GitHub Actions when changes are pushed to the main branch. The workflow will:
+
+1. Replace the `INGRESS_HOST` placeholder with the actual domain
+2. Apply all Kubernetes manifests using Kustomize
+3. Verify the deployment status
+
+## Local Testing
+
+To test the configuration locally:
+
+```bash
+# Replace INGRESS_HOST with your domain
+sed -i "s/INGRESS_HOST/your-domain.com/g" ingress.yaml
+
+# Apply the configuration
+kubectl apply -k .
+```

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: brave-search-mcp-ingress
+  namespace: mcp
+  annotations:
+    kubernetes.io/ingress.class: "gce"
+    kubernetes.io/ingress.global-static-ip-name: "brave-search-mcp-ip"
+    networking.gke.io/managed-certificates: "brave-search-mcp-cert"
+    kubernetes.io/ingress.allow-http: "false"
+spec:
+  rules:
+  - host: INGRESS_HOST
+    http:
+      paths:
+      - path: /v1/brave-search/*
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: brave-search-mcp
+            port:
+              number: 80
+---
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: brave-search-mcp-cert
+  namespace: mcp
+spec:
+  domains:
+    - INGRESS_HOST

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - hpa.yaml
   - networkpolicy.yaml
   - backendconfig.yaml
+  - ingress.yaml
 
 commonLabels:
   project: brave-search-mcp


### PR DESCRIPTION
## Summary

This PR adds ingress configuration for the Brave Search MCP server deployment on GKE with proper environment variable support for open source projects.

## Changes

- **Add ingress.yaml**: GKE ingress configuration with managed certificates
- **Update GitHub Actions**: Inject INGRESS_HOST variable during deployment  
- **Add k8s README**: Documentation for deployment configuration
- **Update kustomization.yaml**: Include ingress resource

## Features

- Uses placeholder replacement for domain configuration
- Supports different domains across environments
- Maintains open source compatibility by avoiding hardcoded domains
- Includes comprehensive documentation

## Configuration Required

The following GitHub secret needs to be added:
- `INGRESS_HOST`: Domain name for the ingress (e.g., `mcp.example.com`)

## Testing

The configuration has been tested with the existing GKE deployment workflow and follows the same patterns as the neo4j ingress configuration.