### PR TITLE
fix: Resolve ingress IP conflicts and TLS configuration issues

### DIFF
--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -5,14 +5,10 @@ metadata:
   namespace: mcp
   annotations:
     kubernetes.io/ingress.class: "gce"
-    kubernetes.io/ingress.global-static-ip-name: "prod-autopilot-us-central-ip"
+    kubernetes.io/ingress.global-static-ip-name: "brave-search-ip"
     networking.gke.io/managed-certificates: "brave-search-mcp-cert"
     kubernetes.io/ingress.allow-http: "false"
 spec:
-  tls:
-  - hosts:
-    - INGRESS_HOST
-    secretName: brave-search-mcp-cert-secret
   rules:
   - host: INGRESS_HOST
     http:


### PR DESCRIPTION
## Summary

This PR fixes ingress configuration issues including IP address conflicts and TLS setup for Google Managed Certificates.

## Issues Fixed

- **IP Address Conflict**: Use separate static IP to avoid conflicts with Neo4j ingress
- **TLS Configuration Error**: Removed inappropriate TLS section for Google Managed Certificates
- **Load Balancer Creation**: Resolves load balancer creation failures

## Changes

- Use dedicated static IP `brave-search-ip` (34.13.118.173)
- Remove TLS section - Google handles this automatically for managed certificates
- Proper ingress configuration for GKE load balancer

## Static IP Addresses

- **Neo4j**: 34.54.166.8 (`prod-autopilot-us-central-ip`)
- **Brave Search**: 34.13.118.173 (`brave-search-ip`)

## DNS Configuration

Requires Cloudflare DNS:
- `mcp-brave-search.memenow.net → 34.13.118.173`