### PR TITLE
Remove nodeSelector, tolerations, and affinity for GKE Autopilot compatibility

### DIFF
--- a/k8s/overlays/production/patches.yaml
+++ b/k8s/overlays/production/patches.yaml
@@ -9,6 +9,10 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
         cloud.google.com/backend-config: '{"default": "brave-mcp-backend-config"}'
+    spec:
+      nodeSelector: null
+      tolerations: null
+      affinity: null
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary
Remove nodeSelector, tolerations, and affinity configurations that prevent pods from being scheduled on GKE Autopilot.

## Problem Solved
Fixes pod scheduling issues where deployments were stuck in Pending state due to:
- `nodeSelector: cloud.google.com/extended-duration-pods=500m`
- `tolerations: kubernetes.io/arch=amd64:NoSchedule`

These configurations are incompatible with GKE Autopilot's node management.

## Changes
- Add patches to explicitly set `nodeSelector: null`, `tolerations: null`, and `affinity: null`
- This ensures pods can be scheduled on any available nodes in the Autopilot cluster

## Test Plan
- [x] Updated patches.yaml to remove affinity constraints
- [ ] Verify pods can be scheduled successfully after deployment