### PR TITLE
fix(docker): drop pinned openssl version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:alpine@sha256:5209bcaca9836eb3448b650396213dbe9d9a34d31840c2ae1f206cb2986a8543 AS builder
 
-RUN apk add --no-cache openssl=3.5.5-r0
+RUN apk add --no-cache openssl
 
 WORKDIR /app
 
@@ -16,7 +16,7 @@ RUN npm run build
 
 FROM node:alpine@sha256:5209bcaca9836eb3448b650396213dbe9d9a34d31840c2ae1f206cb2986a8543 AS release
 
-RUN apk add --no-cache openssl=3.5.5-r0
+RUN apk add --no-cache openssl
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
Drop the pinned `openssl=3.5.5-r0` in `Dockerfile` so Docker Build
Validation stops failing each time Alpine retires the pinned package
revision.

## Related
- Failing run: https://github.com/memenow/brave-search-mcp-server/actions/runs/25739324197

## Updates
| Item | From | To | Notes |
| --- | --- | --- | --- |
| Dockerfile openssl install | `apk add --no-cache openssl=3.5.5-r0` (x2) | `apk add --no-cache openssl` (x2) | both build and release stages |

## Details

### Drop expired openssl pin
- Design/Spec: Alpine's stable repo only retains the current version of each package. Once `3.5.5-r0` is superseded the precise pin stops resolving and `apk add` exits non-zero, breaking every push build until the pin is bumped. The base `node:alpine` image is still pinned by sha256 digest, so layer reproducibility is preserved; the apk pin was the only fragile piece.
- Implementation notes: change applies to both the `builder` and `release` stages (lines 3 and 19). `Dockerfile.cloudflare` does not install openssl via apk and is unaffected.
- Reviewer focus: if the original pin was added to satisfy a specific CVE remediation requirement, a follow-up may need to add a Dockerfile-level assertion (e.g. `openssl version` check) or move the constraint into the security scan config rather than into apk.

## Testing
- Local: not run (no Docker available in this environment); CI Docker Build Validation on the PR is the source of truth.
- Manual steps: rely on the PR's `Docker Build Validation` job — the fix is validated when that check turns green.

## Screenshots / Notes
- Not applicable

## Breaking changes
- Not applicable

## Risks and rollout
- Risk: Alpine could ship a regressed openssl. Mitigation: the base image sha256 pin still locks the toolchain layer; openssl is patched forward inside that layer rather than backward, and the Security workflow's dependency / container scans will flag known CVEs.
- Risk: drift from upstream `brave/brave-search-mcp-server` Dockerfile. Mitigation: the next upstream sync will reintroduce a fresh pin; this fix unblocks CI in the meantime.

## Checklist
- [x] Tests added/updated if needed (n/a — Dockerfile change validated by CI)
- [x] Docs updated if needed (n/a)
- [x] Backward compatibility considered (runtime image surface unchanged)
- [x] Rollout/monitoring considerations noted (security scans still cover openssl)