### PR TITLE
feat(worker): require bearer auth on public route

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ Package manager: **npm** (only `package-lock.json` is committed).
 - `BRAVE_MCP_PORT` (default `8000`), `BRAVE_MCP_HOST` (default `0.0.0.0`), `BRAVE_MCP_LOG_LEVEL` (default `info`).
 - `BRAVE_MCP_ENABLED_TOOLS` / `BRAVE_MCP_DISABLED_TOOLS` — comma-separated tool allow/deny list.
 - `BRAVE_MCP_STATELESS` — HTTP stateless mode; default `true` (required for AWS Bedrock AgentCore).
+- `MCP_AUTH_TOKEN` — **Workers deployment only**; Bearer token required on the public `/brave/mcp` route. Set via `wrangler secret put MCP_AUTH_TOKEN`. Not consumed by the Node-side server.
 
 No `.env.example` exists; see `README.md` for the canonical list.
 
@@ -68,6 +69,7 @@ TypeScript: `strict: true`, `ES2022`, `NodeNext` module + resolution. Project is
 - Cloudflare Containers are wired as **Durable Objects with SQLite** (`migrations[].tag: "v1"`, `new_sqlite_classes: ["BraveSearchContainer"]`). Renaming or removing the class requires a new migration tag — never edit the existing one.
 - `Dockerfile` (generic) and `Dockerfile.cloudflare` (Workers Container image) are distinct; the Cloudflare deploy uses the latter via `wrangler.jsonc`.
 - `BRAVE_API_KEY` must be set on the Cloudflare side (`wrangler secret put BRAVE_API_KEY`) before `cf:deploy`; it is not bundled.
+- `src/worker.ts` exposes two distinct path namespaces: `/brave/*` (public, served by the `routes` entry in `wrangler.jsonc`, Bearer-auth on `/brave/mcp`) and `/internal/mcp` (service-binding-only, no auth, no public route). The `/internal/*` path is **load-bearing** for other Workers in the account that bind this service — do not rename or move it without updating consumer Workers.
 - Smithery has its own build pipeline (`smithery:build`) and reads `smithery.yaml` + `server.json` — keep those in sync with `package.json` `version` on releases.
 - Response schema for `brave_image_search` changed in v2 (no base64 payload); see `README.md` migration notes when touching image-tool callers.
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,73 @@ Options:
   --stateless  <boolean>      HTTP Stateless flag
 ```
 
+## Cloudflare Workers deployment
+
+This fork is also deployed as a Cloudflare Worker + Container. The Worker entry point (`src/worker.ts`) terminates Bearer auth on the public surface and forwards to the containerized HTTP MCP server.
+
+### Routing topology
+
+| Caller | URL | Auth |
+| --- | --- | --- |
+| Public client (Claude Desktop, curl, etc.) | `https://mcp.memenow.xyz/brave/mcp` | `Authorization: Bearer ${MCP_AUTH_TOKEN}` |
+| Public health probe | `https://mcp.memenow.xyz/brave/ping` | none |
+| Internal Worker (same Cloudflare account) | `env.BRAVE_MCP.fetch(new Request("https://internal/internal/mcp", …))` | none — service binding bypasses the public route |
+| Anything else on the public surface | — | `404` |
+
+`workers.dev` is disabled (`workers_dev: false` in `wrangler.jsonc`), so the `/internal/*` path cannot leak through the default subdomain.
+
+### Required secrets
+
+Set these via `wrangler secret put` before `npm run cf:deploy`:
+
+- `BRAVE_API_KEY` — upstream Brave Search API key.
+- `MCP_AUTH_TOKEN` — shared secret for public Bearer auth. Generate with `openssl rand -hex 32` or equivalent.
+
+### Public client example
+
+```bash
+curl -X POST https://mcp.memenow.xyz/brave/mcp \
+  -H "Authorization: Bearer $MCP_AUTH_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+### Service-binding example (other Worker in same account)
+
+In the calling Worker's `wrangler.jsonc`:
+
+```jsonc
+"services": [
+  { "binding": "BRAVE_MCP", "service": "brave-search-mcp-server" }
+]
+```
+
+In the calling Worker's code:
+
+```ts
+const res = await env.BRAVE_MCP.fetch(
+  new Request('https://internal/internal/mcp', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+  })
+);
+```
+
+No `Authorization` header is required — service-binding calls do not traverse the public edge and therefore bypass the public route's Bearer check.
+
+### Local development
+
+```bash
+cat > .dev.vars <<'EOF'
+BRAVE_API_KEY = "<your-brave-key>"
+MCP_AUTH_TOKEN = "dev-token-123"
+EOF
+npm run cf:dev
+```
+
+The dev server listens on `http://localhost:8787`. Public paths are `/brave/mcp` and `/brave/ping`; the service-binding-only path is `/internal/mcp`.
+
 ## Installation
 
 ### Installing via Smithery

--- a/src/worker-auth.ts
+++ b/src/worker-auth.ts
@@ -1,0 +1,24 @@
+/**
+ * Auth helpers for the Cloudflare Worker entry point.
+ * Runs on the Workers runtime; uses Web Crypto, not Node crypto.
+ */
+
+const encoder = new TextEncoder();
+
+/**
+ * Constant-time comparison of an Authorization Bearer header against an expected token.
+ * Returns false when the header is missing, mis-formatted, or the token does not match.
+ */
+export function verifyBearer(request: Request, expected: string): boolean {
+  const header = request.headers.get('authorization');
+  if (!header) return false;
+
+  const [scheme, token] = header.split(' ', 2);
+  if (scheme?.toLowerCase() !== 'bearer' || !token) return false;
+
+  const provided = encoder.encode(token);
+  const target = encoder.encode(expected);
+  if (provided.byteLength !== target.byteLength) return false;
+
+  return crypto.subtle.timingSafeEqual(provided, target);
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,8 +1,13 @@
 /**
  * Cloudflare Worker entry point for Brave Search MCP Server.
- * This worker routes requests to the containerized MCP HTTP server.
+ *
+ * Public surface is served under the configured Workers route (e.g. `mcp.memenow.xyz/brave/*`)
+ * and requires `Authorization: Bearer ${MCP_AUTH_TOKEN}` on `/brave/mcp`. The `/internal/mcp`
+ * path has no public route mapped to it and is reachable only via service bindings from other
+ * Workers in the same account — those callers do not carry a credential.
  */
 import { Container, getContainer } from '@cloudflare/containers';
+import { verifyBearer } from './worker-auth.js';
 
 /**
  * Brave Search MCP Container configuration.
@@ -28,45 +33,74 @@ export class BraveSearchContainer extends Container {
 
 /**
  * Environment interface for the Worker.
- * BRAVE_API_KEY is set via Wrangler Secrets (not in vars).
+ * Secrets are set via `wrangler secret put …` and never bundled.
  */
 interface Env {
   BRAVE_SEARCH_CONTAINER: DurableObjectNamespace<BraveSearchContainer>;
   BRAVE_API_KEY: string;
+  MCP_AUTH_TOKEN: string;
 }
 
-/**
- * Worker fetch handler.
- * Routes MCP and health-check requests to the Brave Search MCP Container.
- */
+type Route = { rewriteTo: string; requireAuth: boolean };
+
+const ROUTES: Record<string, Route> = {
+  '/brave/mcp': { rewriteTo: '/mcp', requireAuth: true },
+  '/brave/ping': { rewriteTo: '/ping', requireAuth: false },
+  // Service-binding-only: not exposed via any public Workers route.
+  '/internal/mcp': { rewriteTo: '/mcp', requireAuth: false },
+};
+
+const jsonResponse = (
+  status: number,
+  body: Record<string, unknown>,
+  extraHeaders?: HeadersInit
+): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...(extraHeaders ?? {}) },
+  });
+
 export default {
   async fetch(request: Request, env: Env, _ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
+    const route = ROUTES[url.pathname];
 
-    // Only allow known MCP paths
-    if (url.pathname !== '/mcp' && url.pathname !== '/ping') {
-      return new Response(JSON.stringify({ error: 'Not Found', message: 'Use /mcp or /ping' }), {
-        status: 404,
-        headers: { 'Content-Type': 'application/json' },
+    if (!route) {
+      return jsonResponse(404, {
+        error: 'Not Found',
+        message: 'Use /brave/mcp or /brave/ping',
       });
     }
 
-    // Validate that BRAVE_API_KEY is configured
     if (!env.BRAVE_API_KEY) {
-      return new Response(
-        JSON.stringify({
-          error: 'Configuration Error',
-          message:
-            'BRAVE_API_KEY is not configured. Set it using: wrangler secret put BRAVE_API_KEY',
-        }),
-        {
-          status: 500,
-          headers: { 'Content-Type': 'application/json' },
-        }
-      );
+      return jsonResponse(500, {
+        error: 'Configuration Error',
+        message: 'BRAVE_API_KEY is not configured. Set it using: wrangler secret put BRAVE_API_KEY',
+      });
     }
 
-    // Get the container instance and forward the request
+    if (route.requireAuth) {
+      if (!env.MCP_AUTH_TOKEN) {
+        return jsonResponse(500, {
+          error: 'Configuration Error',
+          message:
+            'MCP_AUTH_TOKEN is not configured. Set it using: wrangler secret put MCP_AUTH_TOKEN',
+        });
+      }
+      if (!verifyBearer(request, env.MCP_AUTH_TOKEN)) {
+        return jsonResponse(
+          401,
+          { error: 'Unauthorized', message: 'Bearer token required' },
+          { 'WWW-Authenticate': 'Bearer' }
+        );
+      }
+    }
+
+    // Rewrite the path before forwarding so the containerized Express app (which only
+    // serves /mcp and /ping) keeps working unchanged.
+    url.pathname = route.rewriteTo;
+    const forwarded = new Request(url.toString(), request);
+
     const container = getContainer(env.BRAVE_SEARCH_CONTAINER, 'default');
 
     try {
@@ -78,20 +112,14 @@ export default {
         },
       });
 
-      return container.fetch(request);
+      return container.fetch(forwarded);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown error';
       console.error('Container startup failed:', message);
-      return new Response(
-        JSON.stringify({
-          error: 'Container Error',
-          message: `Failed to start MCP container: ${message}`,
-        }),
-        {
-          status: 503,
-          headers: { 'Content-Type': 'application/json' },
-        }
-      );
+      return jsonResponse(503, {
+        error: 'Container Error',
+        message: `Failed to start MCP container: ${message}`,
+      });
     }
   },
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "resolveJsonModule": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "src/worker.ts"]
+  "exclude": ["node_modules", "src/worker.ts", "src/worker-auth.ts"]
 }

--- a/tsconfig.worker.json
+++ b/tsconfig.worker.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "types": ["@cloudflare/workers-types"]
   },
-  "include": ["src/worker.ts"]
+  "include": ["src/worker.ts", "src/worker-auth.ts"]
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,6 +8,14 @@
   "compatibility_flags": ["nodejs_compat"],
   "tsconfig": "tsconfig.worker.json",
 
+  // Public surface lives under the routed prefix only. The `/internal/*` path
+  // used by service-binding callers has no Workers route mapped to it, so it
+  // is unreachable from the public internet.
+  "workers_dev": false,
+  "routes": [{ "pattern": "mcp.memenow.xyz/brave/*", "zone_name": "memenow.xyz" }],
+
+  "observability": { "enabled": true },
+
   // Container configuration (array format for wrangler 4.x)
   "containers": [
     {


### PR DESCRIPTION
## Summary
Adds Bearer-token authentication on the public Workers route while leaving Cloudflare service-binding callers credential-free — service bindings call into the Worker without traversing the public edge, so they bypass the public route by design.

## Related
- Not applicable

## Updates
| Item | From | To | Notes |
| --- | --- | --- | --- |
| `src/worker.ts` | unauthenticated `/mcp` + `/ping` passthrough | path-dispatched `/brave/mcp` (Bearer) + `/brave/ping` + `/internal/mcp` (service-binding only); URL rewritten before `container.fetch(...)` | container's Express app (`src/protocols/http.ts`) stays untouched and keeps serving `/mcp` and `/ping` |
| `src/worker-auth.ts` (new) | — | timing-safe Bearer verifier using `crypto.subtle.timingSafeEqual` | ~22 lines, single-purpose |
| `wrangler.jsonc` | no `routes`, default `workers.dev` enabled | `workers_dev: false`, `routes: [{ pattern: "mcp.memenow.xyz/brave/*", zone_name: "memenow.xyz" }]`, `observability.enabled: true` | the `/internal/*` path has no route mapped to it, so it is unreachable from the public internet |
| `tsconfig.json` / `tsconfig.worker.json` | `worker.ts` excluded from Node target only | also exclude `worker-auth.ts` from Node target; include it in the Workers target | required because `crypto.subtle.timingSafeEqual` is a Workers-runtime extension, not in `lib.dom` |
| `README.md` / `CLAUDE.md` | no auth or routing documentation | new "Cloudflare Workers deployment" section with topology table, secret setup, public + service-binding usage; `MCP_AUTH_TOKEN` documented + gotcha about the load-bearing `/internal/*` path | — |

## Details
### Update Worker entry to dispatch on URL path with Bearer auth on public route
- Design/Spec: see `/home/billduke/.claude/plans/cached-floating-fiddle.md` (local plan; mirrored in the README "Cloudflare Workers deployment" section).
- Implementation notes:
  - Path table `ROUTES` maps each public/internal path to its rewritten downstream path and whether auth is required.
  - Bearer check uses `crypto.subtle.timingSafeEqual` on `TextEncoder`-encoded `Uint8Array`s and short-circuits on unequal lengths to avoid the throw documented for that API.
  - `MCP_AUTH_TOKEN` fails closed with `500` when unset on a Bearer-required path, matching the existing `BRAVE_API_KEY` pattern; no silent unauthenticated fallback.
  - Path rewrite happens before `container.fetch(...)` so the existing containerized Express app (`/mcp`, `/ping`) keeps working without changes.
  - `workers_dev: false` ensures the default `<worker>.workers.dev` subdomain cannot expose `/internal/*` as a backdoor.
- Reviewer focus:
  - The decision to distinguish public vs internal by URL path rather than by the `CF-Worker` header — CF docs explicitly warn against using that header for security decisions because it is added after WAF runs.
  - The `routes` pattern and `zone_name` must match the live Cloudflare zone exactly, or `wrangler deploy` will reject the route.
  - The Workers-target tsconfig split for the new `worker-auth.ts` file.

## Testing
- `npm run format:check` — passes
- `npm run lint` — 0 errors, 9 pre-existing warnings (all upstream, untouched here)
- `npx wrangler deploy --dry-run --outdir=/tmp/brave-mcp-dry` — Worker bundle and Container image both build cleanly
- Manual steps post-merge (recorded in the README): `wrangler secret put MCP_AUTH_TOKEN`, then `curl` against `/brave/mcp` (expect 401 without auth, 200 with valid Bearer) and `/internal/mcp` (expect 404 from the public side)
- Project has no test framework configured (see `CLAUDE.md`); no unit/integration suite was run

## Screenshots / Notes
- Not applicable

## Breaking changes
- `workers.dev` access is disabled. Any tooling that currently calls `<worker>.workers.dev` directly must switch to `https://mcp.memenow.xyz/brave/mcp` with a Bearer token.
- The public surface moves from `/mcp` to `/brave/mcp` (and `/ping` to `/brave/ping`). Clients hitting the old paths on the routed hostname will receive `404`.

## Risks and rollout
- `MCP_AUTH_TOKEN` must be set as a Wrangler secret before deploy, or every public request will hit the fail-closed `500` branch — mitigation: deploy runbook in the README explicitly calls this out.
- The `mcp.memenow.xyz` zone must exist in the same Cloudflare account as the Worker, otherwise the new `routes` entry will be rejected at deploy — mitigation: confirmed by the maintainer before this PR was opened.
- Service-binding callers depend on the stable path `/internal/mcp` — mitigation: documented as a load-bearing path in `CLAUDE.md` gotchas.

## Checklist
- [ ] Tests added/updated if needed — N/A (project has no test framework)
- [x] Docs updated if needed — README + CLAUDE.md
- [ ] Backward compatibility considered — see "Breaking changes" above
- [x] Rollout/monitoring considerations noted — `observability.enabled: true` added; secret setup in the runbook