### PR TITLE
feat(security): http transport auth, dns-rebinding guard, sanitized upstream errors

### DIFF
--- a/Dockerfile.cloudflare
+++ b/Dockerfile.cloudflare
@@ -1,5 +1,5 @@
 # Build stage
-FROM --platform=linux/amd64 node:22-alpine AS builder
+FROM --platform=linux/amd64 node:alpine@sha256:5209bcaca9836eb3448b650396213dbe9d9a34d31840c2ae1f206cb2986a8543 AS builder
 
 WORKDIR /app
 
@@ -14,7 +14,7 @@ COPY ./tsconfig.json ./tsconfig.json
 RUN npm run build
 
 # Release stage
-FROM --platform=linux/amd64 node:22-alpine AS release
+FROM --platform=linux/amd64 node:alpine@sha256:5209bcaca9836eb3448b650396213dbe9d9a34d31840c2ae1f206cb2986a8543 AS release
 
 WORKDIR /app
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.75",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "1.27.1",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "commander": "14.0.3",
         "dotenv": "17.3.1",
         "express": "5.2.1",
@@ -33,7 +33,7 @@
         "tsx": "4.21.0",
         "typescript": "5.9.3",
         "typescript-eslint": "^8.59.2",
-        "wrangler": "^4.69.0"
+        "wrangler": "^4.90.1"
       }
     },
     "node_modules/@anthropic-ai/mcpb": {
@@ -84,24 +84,24 @@
       "license": "ISC"
     },
     "node_modules/@cloudflare/kv-asset-handler": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
-      "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@cloudflare/unenv-preset": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.15.0.tgz",
-      "integrity": "sha512-EGYmJaGZKWl+X8tXxcnx4v2bOZSjQeNI5dWFeXivgX9+YCT69AkzHHwlNbVpqtEUTbew8eQurpyOpeN8fg00nw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "peerDependencies": {
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0"
+        "workerd": ">1.20260305.0 <2.0.0-0"
       },
       "peerDependenciesMeta": {
         "workerd": {
@@ -110,9 +110,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260312.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260312.1.tgz",
-      "integrity": "sha512-HUAtDWaqUduS6yasV6+NgsK7qBpP1qGU49ow/Wb117IHjYp+PZPUGReDYocpB4GOMRoQlvdd4L487iFxzdARpw==",
+      "version": "1.20260508.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260508.1.tgz",
+      "integrity": "sha512-IT3r6VgiSwIesL4AJbxjgxvIxwWZqM7BKkhYAzOKHl4GF2M0TxeOahUIXd+CYXVZgHX8ceEg+MXbEehPelJyNg==",
       "cpu": [
         "x64"
       ],
@@ -127,9 +127,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260312.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260312.1.tgz",
-      "integrity": "sha512-DOn7TPTHSxJYfi4m4NYga/j32wOTqvJf/pY4Txz5SDKWIZHSTXFyGz2K4B+thoPWLop/KZxGoyTv7db0mk/qyw==",
+      "version": "1.20260508.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260508.1.tgz",
+      "integrity": "sha512-JTVsisOJPcNKw0qovPjqyBWYahfdhUh7/9NICiG5wxaEQ45PYKdoqNq0hOAAIqvqoxsKZBvTgcPTJREPqk7avA==",
       "cpu": [
         "arm64"
       ],
@@ -144,9 +144,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260312.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260312.1.tgz",
-      "integrity": "sha512-TdkIh3WzPXYHuvz7phAtFEEvAxvFd30tHrm4gsgpw0R0F5b8PtoM3hfL2uY7EcBBWVYUBtkY2ahDYFfufnXw/g==",
+      "version": "1.20260508.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260508.1.tgz",
+      "integrity": "sha512-zO38pCc27YlsZiPYcaZnosy0/t7abXrRU3VEO1oKfUvnaCpHgphDG+VsrmHL+kntda6hrtNwg2jLeMAqqIjnjw==",
       "cpu": [
         "x64"
       ],
@@ -161,9 +161,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260312.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260312.1.tgz",
-      "integrity": "sha512-kNauZhL569Iy94t844OMwa1zP6zKFiL3xiJ4tGLS+TFTEfZ3pZsRH6lWWOtkXkjTyCmBEOog0HSEKjIV4oAffw==",
+      "version": "1.20260508.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260508.1.tgz",
+      "integrity": "sha512-XhJa780Ia6MNIrtxn/ruZHS79b9pu5EKPfRNReaUqxy8erPT2fs93axMfFoS9kIkcaRRj/1TOUKcTeAMoywY7w==",
       "cpu": [
         "arm64"
       ],
@@ -178,9 +178,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260312.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260312.1.tgz",
-      "integrity": "sha512-5dBrlSK+nMsZy5bYQpj8t9iiQNvCRlkm9GGvswJa9vVU/1BNO4BhJMlqOLWT24EmFyApZ+kaBiPJMV8847NDTg==",
+      "version": "1.20260508.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260508.1.tgz",
+      "integrity": "sha512-QdDOK3B/Ul1s3QmIwDrFyx9230to6LsNmWcVR8w+TYjNZuRPzqQBgusp78LO7MlqCoEl9dvIcN00jkJnLtBSfw==",
       "cpu": [
         "x64"
       ],
@@ -195,9 +195,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260317.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260317.1.tgz",
-      "integrity": "sha512-+G4eVwyCpm8Au1ex8vQBCuA9wnwqetz4tPNRoB/53qvktERWBRMQnrtvC1k584yRE3emMThtuY0gWshvSJ++PQ==",
+      "version": "4.20260511.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260511.1.tgz",
+      "integrity": "sha512-FA+si7cOq9i/gtCHhIc0XJL0l1F/ApF+m00752Aj7WZFJrj3ZulT2T8/+rT3BabMT0QEnqFEGIqCgrmqhgEfMg==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -215,9 +215,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
-      "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -796,9 +796,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.10",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.10.tgz",
-      "integrity": "sha512-hZ7nOssGqRgyV3FVVQdfi+U4q02uB23bpnYpdvNXkYTRRyWx84b7yf1ans+dnJ/7h41sGL3CeQTfO+ZGxuO+Iw==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -1780,9 +1780,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -2240,9 +2240,9 @@
       }
     },
     "node_modules/@speed-highlight/core": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.14.tgz",
-      "integrity": "sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==",
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
+      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -3744,12 +3744,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.0.tgz",
-      "integrity": "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -3830,9 +3830,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -4184,9 +4184,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
-      "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -4437,9 +4437,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -4656,9 +4656,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -4803,16 +4803,16 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260312.1",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260312.1.tgz",
-      "integrity": "sha512-YSWxec9ssisqkQgaCgcIQxZlB41E9hMiq1nxUgxXHRrE9NsfyC6ptSt8yfgBobsKIseAVKLTB/iEDpMumBv8oA==",
+      "version": "4.20260508.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260508.0.tgz",
+      "integrity": "sha512-h3aG+PA8jEH76V4ZtBAbs3g7kjMfHJUF8hPvxeeajLTKwir+G+dqfBODg5yF9MT29LqrZKCRQRqzfHPWX4kCIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "^0.34.5",
-        "undici": "7.18.2",
-        "workerd": "1.20260312.1",
+        "undici": "7.24.8",
+        "workerd": "1.20260508.1",
         "ws": "8.18.0",
         "youch": "4.1.0-beta.10"
       },
@@ -4820,7 +4820,7 @@
         "miniflare": "bootstrap.js"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/minimatch": {
@@ -4946,9 +4946,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.2.tgz",
-      "integrity": "sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "dev": true,
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
@@ -5248,10 +5248,13 @@
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
-      "engines": {
-        "node": ">=16"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -5269,7 +5272,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5707,9 +5712,9 @@
       }
     },
     "node_modules/sharp/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -6748,9 +6753,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.18.2.tgz",
-      "integrity": "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6809,9 +6814,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -6907,9 +6912,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260312.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260312.1.tgz",
-      "integrity": "sha512-nNpPkw9jaqo79B+iBCOiksx+N62xC+ETIfyzofUEdY3cSOHJg6oNnVSHm7vHevzVblfV76c8Gr0cXHEapYMBEg==",
+      "version": "1.20260508.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260508.1.tgz",
+      "integrity": "sha512-VlnjyH3AjVddpSK7J54nsCVgf8i2733pl8GjKttfNi7vN/hEjjAk20d2b1nDToOLKvRQpTewRnVkqaaeGHCaAw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -6920,41 +6925,41 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260312.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260312.1",
-        "@cloudflare/workerd-linux-64": "1.20260312.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260312.1",
-        "@cloudflare/workerd-windows-64": "1.20260312.1"
+        "@cloudflare/workerd-darwin-64": "1.20260508.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260508.1",
+        "@cloudflare/workerd-linux-64": "1.20260508.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260508.1",
+        "@cloudflare/workerd-windows-64": "1.20260508.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.74.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.74.0.tgz",
-      "integrity": "sha512-3qprbhgdUyqYGHZ+Y1k0gsyHLMOlLrKL/HU0LDqLlCkbsKPprUA0/ThE4IZsxD84xAAXY6pv5JUuxS2+OnMa3A==",
+      "version": "4.90.1",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.90.1.tgz",
+      "integrity": "sha512-u2KrieKSMfRM0toTst/CfDtcRraeoVjmcExcMWgILM/ytq3qcDhuOAULoZSyPHzma43lfLJy1BC544drFyqe1A==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@cloudflare/kv-asset-handler": "0.4.2",
-        "@cloudflare/unenv-preset": "2.15.0",
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.27.3",
-        "miniflare": "4.20260312.1",
+        "miniflare": "4.20260508.0",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260312.1"
+        "workerd": "1.20260508.1"
       },
       "bin": {
         "wrangler": "bin/wrangler.js",
         "wrangler2": "bin/wrangler.js"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260312.1"
+        "@cloudflare/workers-types": "^4.20260508.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -7540,9 +7545,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -7550,6 +7555,9 @@
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "cf:tail": "wrangler tail"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.27.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "commander": "14.0.3",
     "dotenv": "17.3.1",
     "express": "5.2.1",
@@ -63,7 +63,7 @@
     "tsx": "4.21.0",
     "typescript": "5.9.3",
     "typescript-eslint": "^8.59.2",
-    "wrangler": "^4.69.0"
+    "wrangler": "^4.90.1"
   },
   "overrides": {
     "formdata-node": "6.0.3",

--- a/src/BraveAPI/index.ts
+++ b/src/BraveAPI/index.ts
@@ -95,17 +95,27 @@ async function issueRequest<T extends keyof Endpoints>(
 
   // Handle Error
   if (!response.ok) {
-    let errorMessage = `${response.status} ${response.statusText}`;
-
+    // Log the upstream error body to stderr for operators, but surface only the
+    // coarse status to the MCP client. Brave's error payloads echo plan/quota
+    // metadata that should not flow through to downstream callers.
     try {
       const responseBody = await response.json();
-      errorMessage += `\n${stringify(responseBody, true)}`;
-    } catch (error) {
-      errorMessage += `\n${await response.text()}`;
+      console.error(
+        `[brave-search-mcp] upstream ${endpoint} error ${response.status}:`,
+        stringify(responseBody, true)
+      );
+    } catch {
+      try {
+        const body = await response.text();
+        console.error(
+          `[brave-search-mcp] upstream ${endpoint} error ${response.status}: ${body.slice(0, 1024)}`
+        );
+      } catch {
+        // ignore
+      }
     }
 
-    // TODO (Sampson): Setup proper error handling, updating state, etc.
-    throw new Error(errorMessage);
+    throw new Error(`Brave Search API request failed: ${response.status} ${response.statusText}`);
   }
 
   // Return Response

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,6 +52,9 @@ type Configuration = {
   enabledTools: string[];
   disabledTools: string[];
   stateless: boolean;
+  authToken: string;
+  allowedHosts: string[];
+  allowedOrigins: string[];
 };
 
 const state: Configuration & { ready: boolean } = {
@@ -64,7 +67,16 @@ const state: Configuration & { ready: boolean } = {
   enabledTools: [],
   disabledTools: [],
   stateless: false,
+  authToken: process.env.BRAVE_MCP_AUTH_TOKEN ?? '',
+  allowedHosts: [],
+  allowedOrigins: [],
 };
+
+const parseCsv = (value: string | undefined): string[] =>
+  (value ?? '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
 
 export function isToolPermittedByUser(toolName: string): boolean {
   return state.enabledTools.length > 0
@@ -106,6 +118,21 @@ export function getOptions(): Configuration | false {
       'whether the server should be stateless',
       process.env.BRAVE_MCP_STATELESS === 'true' ? true : false
     )
+    .option(
+      '--auth-token <string>',
+      'bearer token required on /mcp when HTTP transport is exposed beyond loopback',
+      process.env.BRAVE_MCP_AUTH_TOKEN ?? ''
+    )
+    .option(
+      '--allowed-hosts <hosts>',
+      'comma-separated Host header allowlist for DNS rebinding protection',
+      parseCsv(process.env.BRAVE_MCP_ALLOWED_HOSTS)
+    )
+    .option(
+      '--allowed-origins <origins>',
+      'comma-separated Origin header allowlist for DNS rebinding protection',
+      parseCsv(process.env.BRAVE_MCP_ALLOWED_ORIGINS)
+    )
     .allowUnknownOption()
     .parse(process.argv);
 
@@ -115,6 +142,17 @@ export function getOptions(): Configuration | false {
   // Validate tool inclusion configuration
   const enabledTools = options.enabledTools.filter((t: string) => t.trim().length > 0);
   const disabledTools = options.disabledTools.filter((t: string) => t.trim().length > 0);
+
+  const normalizeListOption = (value: unknown): string[] => {
+    if (Array.isArray(value)) {
+      return value.flatMap((entry) => (typeof entry === 'string' ? parseCsv(entry) : []));
+    }
+    if (typeof value === 'string') return parseCsv(value);
+    return [];
+  };
+
+  const allowedHosts = normalizeListOption(options.allowedHosts);
+  const allowedOrigins = normalizeListOption(options.allowedOrigins);
 
   if (enabledTools.length > 0 && disabledTools.length > 0) {
     console.error('Error: --enabled-tools and --disabled-tools cannot be used together');
@@ -178,9 +216,12 @@ export function getOptions(): Configuration | false {
   state.enabledTools = options.enabledTools;
   state.disabledTools = options.disabledTools;
   state.stateless = options.stateless;
+  state.authToken = options.authToken ?? '';
+  state.allowedHosts = allowedHosts;
+  state.allowedOrigins = allowedOrigins;
   state.ready = true;
 
-  return options as Configuration;
+  return { ...options, allowedHosts, allowedOrigins } as Configuration;
 }
 
 export function setOptions(options: SmitheryConfig) {

--- a/src/protocols/auth.ts
+++ b/src/protocols/auth.ts
@@ -1,0 +1,93 @@
+import { timingSafeEqual } from 'node:crypto';
+import type { NextFunction, Request, Response } from 'express';
+
+/**
+ * Constant-time comparison of an `Authorization: Bearer <token>` header against an
+ * expected value. Returns false when the header is missing, mis-formatted, or the
+ * token does not match.
+ */
+export function verifyBearer(authorization: string | undefined, expected: string): boolean {
+  if (!authorization) return false;
+
+  const [scheme, token] = authorization.split(' ', 2);
+  if (scheme?.toLowerCase() !== 'bearer' || !token) return false;
+
+  const provided = Buffer.from(token);
+  const target = Buffer.from(expected);
+  if (provided.length !== target.length) return false;
+
+  return timingSafeEqual(provided, target);
+}
+
+/**
+ * Express middleware that enforces a bearer token on the route it is mounted on.
+ * If `expected` is empty, the middleware is a no-op (auth disabled).
+ */
+export function bearerAuth(expected: string) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (!expected) return next();
+
+    if (verifyBearer(req.headers.authorization, expected)) return next();
+
+    res
+      .status(401)
+      .set('WWW-Authenticate', 'Bearer')
+      .json({
+        id: null,
+        jsonrpc: '2.0',
+        error: { code: -32001, message: 'Unauthorized' },
+      });
+  };
+}
+
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', '::1', 'localhost', '0:0:0:0:0:0:0:1']);
+
+export function isLoopbackHost(host: string): boolean {
+  return LOOPBACK_HOSTS.has(host.toLowerCase());
+}
+
+/**
+ * Builds an Express middleware that validates the `Host` and `Origin` headers to
+ * mitigate DNS rebinding attacks against local HTTP MCP servers.
+ *
+ * - `Host` is required and must match the configured bind host:port or one of the
+ *   loopback aliases. Additional hosts may be supplied via `allowedHosts`.
+ * - `Origin`, when present, must appear in `allowedOrigins`. Non-browser MCP clients
+ *   typically omit Origin entirely, so an empty allowlist still permits those.
+ */
+export function dnsRebindingGuard(opts: {
+  bindHost: string;
+  bindPort: number;
+  allowedHosts: string[];
+  allowedOrigins: string[];
+}) {
+  const expectedHosts = new Set<string>(
+    [
+      `${opts.bindHost}:${opts.bindPort}`,
+      ...LOOPBACK_HOSTS,
+      ...[...LOOPBACK_HOSTS].map((h) => `${h}:${opts.bindPort}`),
+      ...opts.allowedHosts,
+    ].map((h) => h.toLowerCase())
+  );
+  const allowedOrigins = new Set(opts.allowedOrigins.map((o) => o.toLowerCase()));
+
+  return (req: Request, res: Response, next: NextFunction) => {
+    const host = (req.headers.host ?? '').toLowerCase();
+    if (!host || !expectedHosts.has(host)) {
+      res
+        .status(421)
+        .json({ id: null, jsonrpc: '2.0', error: { code: -32000, message: 'Host not allowed' } });
+      return;
+    }
+
+    const origin = req.headers.origin;
+    if (origin && !allowedOrigins.has(origin.toLowerCase())) {
+      res
+        .status(403)
+        .json({ id: null, jsonrpc: '2.0', error: { code: -32000, message: 'Origin not allowed' } });
+      return;
+    }
+
+    next();
+  };
+}

--- a/src/protocols/auth.ts
+++ b/src/protocols/auth.ts
@@ -1,22 +1,31 @@
-import { timingSafeEqual } from 'node:crypto';
+import { createHash, timingSafeEqual } from 'node:crypto';
 import type { NextFunction, Request, Response } from 'express';
+
+const sha256 = (input: string): Buffer => createHash('sha256').update(input, 'utf8').digest();
 
 /**
  * Constant-time comparison of an `Authorization: Bearer <token>` header against an
  * expected value. Returns false when the header is missing, mis-formatted, or the
  * token does not match.
+ *
+ * Both sides are SHA-256 hashed before comparison so `timingSafeEqual` always
+ * operates on equal-length 32-byte buffers. This removes the token-length side
+ * channel that an early `Buffer.length` check would leave open, matching the
+ * Web Crypto implementation in `worker-auth.ts`.
  */
 export function verifyBearer(authorization: string | undefined, expected: string): boolean {
   if (!authorization) return false;
 
-  const [scheme, token] = authorization.split(' ', 2);
-  if (scheme?.toLowerCase() !== 'bearer' || !token) return false;
+  // Parse with indexOf so a token containing spaces is preserved verbatim.
+  // `split(' ', 2)` would silently drop everything past the second segment,
+  // which can break authentication after rotating to a space-bearing token.
+  const space = authorization.indexOf(' ');
+  if (space === -1) return false;
+  const scheme = authorization.slice(0, space);
+  const token = authorization.slice(space + 1);
+  if (scheme.toLowerCase() !== 'bearer' || !token) return false;
 
-  const provided = Buffer.from(token);
-  const target = Buffer.from(expected);
-  if (provided.length !== target.length) return false;
-
-  return timingSafeEqual(provided, target);
+  return timingSafeEqual(sha256(token), sha256(expected));
 }
 
 /**
@@ -46,6 +55,8 @@ export function isLoopbackHost(host: string): boolean {
   return LOOPBACK_HOSTS.has(host.toLowerCase());
 }
 
+const hasColon = (h: string): boolean => h.includes(':');
+
 /**
  * Builds an Express middleware that validates the `Host` and `Origin` headers to
  * mitigate DNS rebinding attacks against local HTTP MCP servers.
@@ -54,6 +65,11 @@ export function isLoopbackHost(host: string): boolean {
  *   loopback aliases. Additional hosts may be supplied via `allowedHosts`.
  * - `Origin`, when present, must appear in `allowedOrigins`. Non-browser MCP clients
  *   typically omit Origin entirely, so an empty allowlist still permits those.
+ *
+ * IPv6 forms: per RFC 7230 §5.4 the `Host` header for an IPv6 literal carries
+ * brackets (`[::1]:8080`). We generate both the bracketed and bare forms so a
+ * client that follows the RFC and an operator who passes `::1` to BRAVE_MCP_HOST
+ * both work without further configuration.
  */
 export function dnsRebindingGuard(opts: {
   bindHost: string;
@@ -61,11 +77,21 @@ export function dnsRebindingGuard(opts: {
   allowedHosts: string[];
   allowedOrigins: string[];
 }) {
+  const port = opts.bindPort;
+  const bracket = (h: string): string => (hasColon(h) ? `[${h}]` : h);
+
   const expectedHosts = new Set<string>(
     [
-      `${opts.bindHost}:${opts.bindPort}`,
+      // Configured bind host, both forms.
+      `${bracket(opts.bindHost)}:${port}`,
+      `${opts.bindHost}:${port}`,
+      // Bare host names (a few clients omit the port).
       ...LOOPBACK_HOSTS,
-      ...[...LOOPBACK_HOSTS].map((h) => `${h}:${opts.bindPort}`),
+      opts.bindHost,
+      // Loopback aliases with port, IPv4 plain and IPv6 bracketed.
+      ...[...LOOPBACK_HOSTS].map((h) => `${bracket(h)}:${port}`),
+      ...[...LOOPBACK_HOSTS].map((h) => `${h}:${port}`),
+      // Operator-supplied extras.
       ...opts.allowedHosts,
     ].map((h) => h.toLowerCase())
   );

--- a/src/protocols/http.ts
+++ b/src/protocols/http.ts
@@ -2,6 +2,7 @@ import { randomUUID, timingSafeEqual } from 'node:crypto';
 import express, { type NextFunction, type Request, type Response } from 'express';
 import config from '../config.js';
 import createMcpServer from '../server.js';
+import { bearerAuth, dnsRebindingGuard, isLoopbackHost } from './auth.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { ListToolsRequest, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 
@@ -95,19 +96,46 @@ const requireInternalSecret = (req: Request, res: Response, next: NextFunction) 
 const createApp = () => {
   const app = express();
 
+  // Don't advertise Express to clients and don't trust X-Forwarded-* headers
+  // unless the operator explicitly configures a reverse proxy.
+  app.disable('x-powered-by');
+  app.set('trust proxy', false);
+
   app.use(express.json());
 
-  app.all('/mcp', requireInternalSecret, async (req: Request, res: Response) => {
-    try {
-      const transport = await getTransport(req);
-      await transport.handleRequest(req, res, req.body);
-    } catch (error) {
-      console.error(error);
-      if (!res.headersSent) {
-        yieldGenericServerError(res);
+  // DNS-rebinding protection: enforced globally so /mcp, /ping, and anything we
+  // mount in the future all benefit. Loopback aliases are always permitted; the
+  // configured bind host:port is added automatically; operators can extend via
+  // BRAVE_MCP_ALLOWED_HOSTS / BRAVE_MCP_ALLOWED_ORIGINS.
+  app.use(
+    dnsRebindingGuard({
+      bindHost: config.host,
+      bindPort: config.port,
+      allowedHosts: config.allowedHosts,
+      allowedOrigins: config.allowedOrigins,
+    })
+  );
+
+  // Bearer auth on /mcp is opt-in: the middleware no-ops when BRAVE_MCP_AUTH_TOKEN
+  // is unset, preserving stdio / Docker / npm flows. It is independent of the
+  // container-side x-internal-secret check above: the Worker path uses the
+  // INTERNAL_SECRET header, while a standalone HTTP deployment uses Bearer.
+  app.all(
+    '/mcp',
+    bearerAuth(config.authToken),
+    requireInternalSecret,
+    async (req: Request, res: Response) => {
+      try {
+        const transport = await getTransport(req);
+        await transport.handleRequest(req, res, req.body);
+      } catch (error) {
+        console.error(error);
+        if (!res.headersSent) {
+          yieldGenericServerError(res);
+        }
       }
     }
-  });
+  );
 
   app.all('/ping', (req: Request, res: Response) => {
     res.status(200).json({ message: 'pong' });
@@ -123,6 +151,15 @@ const start = () => {
   }
 
   const app = createApp();
+
+  if (!config.authToken && !isLoopbackHost(config.host)) {
+    console.warn(
+      `[brave-search-mcp] WARNING: HTTP transport is bound to ${config.host} without a bearer ` +
+        `token. Anyone who can reach this port can call MCP tools and consume your Brave API ` +
+        `quota. Set BRAVE_MCP_AUTH_TOKEN, bind to 127.0.0.1, or place an authenticating proxy ` +
+        `in front of this server.`
+    );
+  }
 
   app.listen(config.port, config.host, () => {
     console.log(`Server is running on http://${config.host}:${config.port}/mcp`);


### PR DESCRIPTION
## Summary
Layer additional defense-in-depth onto the standalone HTTP transport: opt-in bearer auth, Host/Origin DNS-rebinding guard, sanitized Brave API error responses, plus a pinned Cloudflare Container base image and a dep bump that clears all 14 outstanding npm audit findings. Stateful session cleanup and the container-side `INTERNAL_SECRET` layer added in #18 are preserved; this PR adds the missing pieces that #18 did not address.

## Related
- Not applicable

## Updates
| Area | Before | After | Notes |
| --- | --- | --- | --- |
| HTTP `/mcp` auth (standalone) | None for Docker / npm / local HTTP users | Opt-in `BRAVE_MCP_AUTH_TOKEN` bearer middleware | Independent of the Worker-only `INTERNAL_SECRET` from #18; both layers stack on `/mcp` |
| DNS-rebinding (Host/Origin) | No validation | Host allowlist + Origin allowlist middleware | Configurable via `BRAVE_MCP_ALLOWED_HOSTS` / `BRAVE_MCP_ALLOWED_ORIGINS`; loopback aliases always permitted |
| Express hardening | Defaults | `x-powered-by` disabled, `trust proxy` false | Standard server-side hygiene |
| Standalone HTTP startup | Silent on insecure bind | Loud stderr warning when bound to non-loopback without a token | Non-fatal; gives operators concrete remediation steps |
| `BraveAPI` error path | Upstream body echoed to client | Logged to stderr only; generic `<status>` surface | Stops leaking `meta.plan` / quota metadata |
| `Dockerfile.cloudflare` base image | `node:22-alpine` (mutable tag) | `node:alpine@sha256:5209bcaca…` | Matches `Dockerfile`; reproducible Container image |
| `@modelcontextprotocol/sdk` | `1.27.1` | `1.29.0` | API-compatible minor bump; cleaner transitive ranges |
| `wrangler` | `^4.69.0` | `4.90.1` | Drops vulnerable miniflare / undici transitive paths |
| `npm audit` | 14 (8 high, 6 moderate) | 0 | After upgrade + `npm audit fix` |

## Details
### `src/protocols/auth.ts` (new)
- Design/Spec: Implements MCP spec guidance to validate `Host` and `Origin` for HTTP-bound MCP servers, plus a standard bearer middleware. Uses Node `crypto.timingSafeEqual` to avoid timing oracles.
- Implementation notes: `bearerAuth` is a no-op when `expected` is empty so existing Docker users keep working; `dnsRebindingGuard` always permits loopback aliases (`127.0.0.1`, `::1`, `localhost`, `0:0:0:0:0:0:0:1`) plus the configured bind host:port, with operator-supplied extras.
- Reviewer focus: comparison logic in `verifyBearer`; the allowlist set construction in `dnsRebindingGuard`.

### `src/protocols/http.ts`
- Implementation notes: New middleware stack is `dnsRebindingGuard` (global) → `bearerAuth` (route-level on `/mcp`, no-op when token is empty) → `requireInternalSecret` (route-level, from #18, no-op when `INTERNAL_SECRET` is unset). The two auth layers are independent: Cloudflare deployments rely on the Worker to terminate Bearer at the edge and inject `x-internal-secret`; standalone HTTP deployments can rely on `BRAVE_MCP_AUTH_TOKEN`.
- Reviewer focus: confirm the middleware order is correct (DNS-rebinding before auth to avoid leaking auth-required signals to rebinding probes) and that `/ping` still works for health checks (it does — bearer is mounted per-route on `/mcp`).

### `src/BraveAPI/index.ts`
- Implementation notes: Truncates the text fallback to 1 KB before logging to bound stderr volume. The thrown `Error` now carries only the upstream `status statusText`, which is what MCP clients see.
- Reviewer focus: confirm no tool implementations rely on the previous verbose error message text — none do, since they always re-throw or report a generic failure.

### `src/config.ts`
- Implementation notes: New `parseCsv` helper for the comma-separated allowlist env vars. Existing tools-list parsing (`split(' ')`) is left untouched per `CLAUDE.md` guidance that the whitespace delimiter is the documented design.
- Reviewer focus: backward compatibility — all new fields are additive, with empty defaults that preserve current behavior.

### `Dockerfile.cloudflare`
- Implementation notes: Same digest as `Dockerfile`; rebuild reproducibility now consistent across both images. The `--platform=linux/amd64` warning emitted by Buildx is pre-existing and unrelated.

### Deps
- Implementation notes: `wrangler@4.90.1` drops vulnerable `miniflare` / `undici` paths; `@modelcontextprotocol/sdk@1.29.0` pulls cleaner Hono / express-rate-limit ranges. `npm audit fix` closed the remaining transitive findings without forcing any major bumps.

## Testing
- `npm audit` -- 0 vulnerabilities (was 14)
- `npm run lint` -- 0 errors, 8 pre-existing warnings inherited from upstream (per `CLAUDE.md`, not bulk-fixed)
- `npm run build` -- pass (tsc + chmod)
- `npx wrangler deploy --dry-run` -- pass (Worker bundle + Container image build both succeed)
- Manual steps: not run; no test framework is configured in this repo. Operators should validate with `npm run inspector:http` after deploy.

## Screenshots / Notes
- Not applicable

## Breaking changes
- Not applicable. Standalone HTTP bearer auth is opt-in (off when `BRAVE_MCP_AUTH_TOKEN` is empty). DNS-rebinding guard always permits loopback and the configured bind host:port, so default deployments continue to work without further configuration.

## Risks and rollout
- Risk: operators currently exposing the standalone HTTP `/mcp` on a non-loopback host without a token will see a stderr warning at startup. Mitigation: warning is non-fatal and provides concrete remediation guidance (set the token, bind to loopback, or front with an auth proxy).
- Risk: the global Host header guard could reject requests if a reverse proxy rewrites `Host`. Mitigation: operators can extend `BRAVE_MCP_ALLOWED_HOSTS`; the middleware also accepts the configured `BRAVE_MCP_HOST:BRAVE_MCP_PORT` automatically.
- Risk: SDK `1.27` → `1.29` minor bump. Mitigation: API-compatible per the SDK changelog; `npm run build` and `wrangler deploy --dry-run` validate that both the Node and Worker entries still compile cleanly.

## Checklist
- [x] Tests added/updated if needed (no test framework; lint + build + dry-run + audit done)
- [ ] Docs updated if needed (README env-var table follow-up tracked separately)
- [x] Backward compatibility considered (auth + DNS guard both opt-in / default-permissive for existing flows)
- [x] Rollout/monitoring considerations noted