### PR TITLE
revert(worker): drop INTERNAL_SECRET defense-in-depth layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,11 +39,10 @@ Package manager: **npm** (only `package-lock.json` is committed).
 
 - `BRAVE_API_KEY` — required for every transport.
 - `BRAVE_MCP_TRANSPORT` — `stdio` (default) or `http`.
-- `BRAVE_MCP_PORT` (code default `8080`; see `src/config.ts`), `BRAVE_MCP_HOST` (default `0.0.0.0`), `BRAVE_MCP_LOG_LEVEL` (default `info`).
+- `BRAVE_MCP_PORT` (default `8080`, see `src/config.ts:97`), `BRAVE_MCP_HOST` (default `0.0.0.0`), `BRAVE_MCP_LOG_LEVEL` (default `info`).
 - `BRAVE_MCP_ENABLED_TOOLS` / `BRAVE_MCP_DISABLED_TOOLS` — whitespace-separated tool allow/deny list (parsed via `split(' ')` in `src/config.ts`).
-- `BRAVE_MCP_STATELESS` — HTTP stateless mode. **Code default is `false`** (`src/config.ts` schema + state both default to `false`); set the env var to `"true"` for AWS Bedrock AgentCore. The upstream README states a default of `"true"` — that line is inconsistent with the code; treat the source as authoritative.
+- `BRAVE_MCP_STATELESS` — HTTP stateless mode; schema and runtime defaults are `false` (`src/config.ts:39`, `:66`). The CLI normaliser only flips to `true` when `process.env.BRAVE_MCP_STATELESS === 'true'` (`src/config.ts:107`), so AWS Bedrock AgentCore deployments must set the env var explicitly.
 - `MCP_AUTH_TOKEN` — **Workers deployment only**; Bearer token required on the public `/brave/mcp` route. Set via `wrangler secret put MCP_AUTH_TOKEN`. Not consumed by the Node-side server.
-- `INTERNAL_SECRET` — **Workers deployment only**; secret the Worker injects as `x-internal-secret` on every request forwarded into the Container, and the container-side Express app verifies on `/mcp` via constant-time compare. Defense in depth against a misconfigured route exposing `/internal/*` directly. Set via `wrangler secret put INTERNAL_SECRET`. The Node-side server treats it as opt-in: unset = no check (preserves stdio / Docker / npm flows).
 
 No `.env.example` exists; see `README.md` for the canonical list.
 
@@ -69,10 +68,9 @@ TypeScript: `strict: true`, `ES2022`, `NodeNext` module + resolution. Project is
 - `src/worker.ts` and `src/worker-auth.ts` use a **separate** `tsconfig.worker.json`. Node-side `npm run build` will not catch worker-only type errors — run `npm run cf:dev` (or `wrangler deploy --dry-run`) when touching them.
 - Cloudflare Containers are wired as **Durable Objects with SQLite** (`migrations[].tag: "v1"`, `new_sqlite_classes: ["BraveSearchContainer"]`). Renaming or removing the class requires a new migration tag — never edit the existing one.
 - `Dockerfile` (generic) and `Dockerfile.cloudflare` (Workers Container image) are distinct; the Cloudflare deploy uses the latter via `wrangler.jsonc`.
-- `BRAVE_API_KEY`, `MCP_AUTH_TOKEN`, and `INTERNAL_SECRET` must all be set on the Cloudflare side (`wrangler secret put …`) before `cf:deploy`; none are bundled.
-- `src/worker.ts` declares a `ROUTES` table with three entries: `/brave/mcp` (public, requires Bearer auth via `MCP_AUTH_TOKEN`), `/brave/ping` (public, no auth), and `/internal/mcp` (service-binding-only, no Bearer auth, no public route). Public exposure is gated by the `routes` entry in `wrangler.jsonc` (`mcp.memenow.xyz/brave/*`) plus `workers_dev: false`. Both `/brave/mcp` and `/internal/mcp` are additionally protected on the container side by `x-internal-secret` (see `INTERNAL_SECRET` under Required environment). The `/internal/*` path is **load-bearing** for other Workers in the account that bind this service — do not rename or move it without updating consumer Workers.
-- Worker paths are **rewritten** before `container.fetch(...)` (`/brave/mcp` → `/mcp`, `/internal/mcp` → `/mcp`, `/brave/ping` → `/ping`); the Worker also strips the public `Authorization` header and injects `x-internal-secret` on the forwarded request, so the containerized Express app in `src/protocols/http.ts` keeps serving `/mcp` and `/ping` unchanged.
-- `src/worker.ts` fans out across container instances with `getRandom(env.BRAVE_SEARCH_CONTAINER, CONTAINER_FANOUT)`. `CONTAINER_FANOUT` **must match** `wrangler.jsonc containers[].max_instances` — keep them in lockstep when you change either.
+- `BRAVE_API_KEY` and `MCP_AUTH_TOKEN` must be set on the Cloudflare side (`wrangler secret put …`) before `cf:deploy`; neither is bundled.
+- `src/worker.ts` declares a `ROUTES` table with three entries: `/brave/mcp` (public, requires Bearer auth via `MCP_AUTH_TOKEN`), `/brave/ping` (public, no auth), and `/internal/mcp` (service-binding-only, no Bearer auth, no public route). Public exposure is gated by the `routes` entry in `wrangler.jsonc` (`mcp.memenow.xyz/brave/*`) plus `workers_dev: false`. The `/internal/*` path is **load-bearing** for other Workers in the account that bind this service — do not rename or move it without updating consumer Workers.
+- Worker paths are **rewritten** before `container.fetch(...)` (`/brave/mcp` → `/mcp`, `/internal/mcp` → `/mcp`, `/brave/ping` → `/ping`); the containerized Express app in `src/protocols/http.ts` keeps serving `/mcp` and `/ping` unchanged.
 - Smithery has its own build pipeline (`smithery:build`) and reads `smithery.yaml` + `server.json` — keep those (and `marketplace-revision-release.json`) in sync with `package.json` `version` on releases.
 - Response schema for `brave_image_search` changed in v2 (no base64 payload); see `README.md` migration notes when touching image-tool callers.
 

--- a/README.md
+++ b/README.md
@@ -114,12 +114,12 @@ The server supports the following environment variables:
 
 - `BRAVE_API_KEY`: Your Brave Search API key (required)
 - `BRAVE_MCP_TRANSPORT`: Transport mode ("http" or "stdio", default: "stdio")
-- `BRAVE_MCP_PORT`: HTTP server port (default: 8000)
+- `BRAVE_MCP_PORT`: HTTP server port (default: 8080)
 - `BRAVE_MCP_HOST`: HTTP server host (default: "0.0.0.0")
 - `BRAVE_MCP_LOG_LEVEL`: Desired logging level("debug", "info", "notice", "warning", "error", "critical", "alert", or "emergency", default: "info")
 - `BRAVE_MCP_ENABLED_TOOLS`: When used, specifies a whitelist for supported tools
 - `BRAVE_MCP_DISABLED_TOOLS`: When used, specifies a blacklist for supported tools
-- `BRAVE_MCP_STATELESS`: HTTP stateless mode (default: "true").  When running on Amazon Bedrock Agentcore, set to "true".
+- `BRAVE_MCP_STATELESS`: HTTP stateless mode (default: "false"). Set to "true" when running on Amazon Bedrock AgentCore.
 
 ### Command Line Options
 
@@ -158,7 +158,6 @@ Set these via `wrangler secret put` before `npm run cf:deploy`:
 
 - `BRAVE_API_KEY` — upstream Brave Search API key.
 - `MCP_AUTH_TOKEN` — shared secret for public Bearer auth. Generate with `openssl rand -hex 32` or equivalent.
-- `INTERNAL_SECRET` — defense-in-depth secret the Worker injects as `x-internal-secret` on every request it forwards into the Container; the container-side Express app rejects any `/mcp` request whose header does not match. Generate independently from `MCP_AUTH_TOKEN` with `openssl rand -hex 32`.
 
 ### Public client example
 
@@ -199,7 +198,6 @@ No `Authorization` header is required — service-binding calls do not traverse 
 cat > .dev.vars <<'EOF'
 BRAVE_API_KEY = "<your-brave-key>"
 MCP_AUTH_TOKEN = "dev-token-123"
-INTERNAL_SECRET = "dev-internal-secret-456"
 EOF
 npm run cf:dev
 ```
@@ -396,8 +394,8 @@ STDIO is the default mode. For HTTP mode testing, add `--transport http` to the 
 - `npm run format:check`: Check code formatting
 - `npm run prepare`: Format and build (runs automatically on npm install)
 
-- `npm run inspector`: Launch an instance of MCP Inspector
-- `npm run inspector:stdio`: Launch a instance of MCP Inspector, configured for STDIO
+- `npm run inspector`: Launch an instance of MCP Inspector (STDIO)
+- `npm run inspector:http`: Launch an instance of MCP Inspector configured for HTTP transport
 - `npm run smithery:build`: Build the project for smithery.ai
 - `npm run smithery:dev`: Launch the development environment for smithery.ai
 

--- a/src/protocols/http.ts
+++ b/src/protocols/http.ts
@@ -1,5 +1,5 @@
-import { randomUUID, timingSafeEqual } from 'node:crypto';
-import express, { type NextFunction, type Request, type Response } from 'express';
+import { randomUUID } from 'node:crypto';
+import express, { type Request, type Response } from 'express';
 import config from '../config.js';
 import createMcpServer from '../server.js';
 import { bearerAuth, dnsRebindingGuard, isLoopbackHost } from './auth.js';
@@ -46,51 +46,18 @@ const getTransport = async (request: Request): Promise<StreamableHTTPServerTrans
       sessionIdGenerator: undefined,
     });
   } else {
-    // Stateful: register the transport in `transports` on session init and remove it
-    // on close so the map cannot grow without bound while the server runs.
+    // Otherwise, start a new transport/session
     transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: () => randomUUID(),
       onsessioninitialized: (sessionId) => {
         transports.set(sessionId, transport);
       },
     });
-    transport.onclose = () => {
-      if (transport.sessionId) {
-        transports.delete(transport.sessionId);
-      }
-    };
   }
 
   const mcpServer = createMcpServer();
   await mcpServer.connect(transport);
   return transport;
-};
-
-/**
- * Container-side defense in depth: the Cloudflare Worker injects `x-internal-secret`
- * on every forwarded /mcp request. We constant-time compare it against the
- * INTERNAL_SECRET env var so that even if the container port is reached directly
- * (route misconfig, accidental publish, etc.) the Brave API quota stays protected.
- *
- * The check is opt-in: if INTERNAL_SECRET is unset (e.g. local stdio dev, plain
- * `npx` consumers, Docker users) the middleware passes through unchanged.
- */
-const requireInternalSecret = (req: Request, res: Response, next: NextFunction) => {
-  const expected = process.env.INTERNAL_SECRET;
-  if (!expected) return next();
-
-  const provided = req.header('x-internal-secret') ?? '';
-  const a = Buffer.from(provided);
-  const b = Buffer.from(expected);
-  if (a.length !== b.length || !timingSafeEqual(a, b)) {
-    res.status(401).json({
-      id: null,
-      jsonrpc: '2.0',
-      error: { code: -32001, message: 'Unauthorized' },
-    });
-    return;
-  }
-  next();
 };
 
 const createApp = () => {
@@ -117,25 +84,18 @@ const createApp = () => {
   );
 
   // Bearer auth on /mcp is opt-in: the middleware no-ops when BRAVE_MCP_AUTH_TOKEN
-  // is unset, preserving stdio / Docker / npm flows. It is independent of the
-  // container-side x-internal-secret check above: the Worker path uses the
-  // INTERNAL_SECRET header, while a standalone HTTP deployment uses Bearer.
-  app.all(
-    '/mcp',
-    bearerAuth(config.authToken),
-    requireInternalSecret,
-    async (req: Request, res: Response) => {
-      try {
-        const transport = await getTransport(req);
-        await transport.handleRequest(req, res, req.body);
-      } catch (error) {
-        console.error(error);
-        if (!res.headersSent) {
-          yieldGenericServerError(res);
-        }
+  // is unset, preserving stdio / Docker / npm flows.
+  app.all('/mcp', bearerAuth(config.authToken), async (req: Request, res: Response) => {
+    try {
+      const transport = await getTransport(req);
+      await transport.handleRequest(req, res, req.body);
+    } catch (error) {
+      console.error(error);
+      if (!res.headersSent) {
+        yieldGenericServerError(res);
       }
     }
-  );
+  });
 
   app.all('/ping', (req: Request, res: Response) => {
     res.status(200).json({ message: 'pong' });

--- a/src/protocols/http.ts
+++ b/src/protocols/http.ts
@@ -46,13 +46,19 @@ const getTransport = async (request: Request): Promise<StreamableHTTPServerTrans
       sessionIdGenerator: undefined,
     });
   } else {
-    // Otherwise, start a new transport/session
+    // Stateful: register the transport on session init and evict it on close so
+    // the Map cannot grow without bound while the server runs.
     transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: () => randomUUID(),
       onsessioninitialized: (sessionId) => {
         transports.set(sessionId, transport);
       },
     });
+    transport.onclose = () => {
+      if (transport.sessionId) {
+        transports.delete(transport.sessionId);
+      }
+    };
   }
 
   const mcpServer = createMcpServer();

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -114,12 +114,15 @@ export default {
         },
       });
 
-      return container.fetch(forwarded);
+      // Await so rejections from container.fetch (e.g. the container exits
+      // between readiness and fetch, or the connection is reset) land in the
+      // catch below instead of escaping as an unhandled Worker error.
+      return await container.fetch(forwarded);
     } catch (err) {
       // Log the underlying cause for operators; return a generic message so
       // backend infrastructure detail never leaks to the public surface.
       const detail = err instanceof Error ? err.message : 'Unknown error';
-      console.error('Container startup failed:', detail);
+      console.error('Container request failed:', detail);
       return jsonResponse(503, {
         error: 'Service Unavailable',
         message: 'Backend temporarily unavailable',

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5,51 +5,22 @@
  * and requires `Authorization: Bearer ${MCP_AUTH_TOKEN}` on `/brave/mcp`. The `/internal/mcp`
  * path has no public route mapped to it and is reachable only via service bindings from other
  * Workers in the same account — those callers do not carry a credential.
- *
- * Defense in depth: every request the Worker forwards into the Container carries an
- * `x-internal-secret: ${INTERNAL_SECRET}` header, and the container-side Express app
- * rejects any /mcp request whose header does not match. This way, even if a routes
- * entry accidentally exposes /internal/*, or the container port is reached directly,
- * Brave Search API quota stays protected.
  */
-import { Container, getRandom } from '@cloudflare/containers';
+import { Container, getContainer } from '@cloudflare/containers';
 import { verifyBearer } from './worker-auth.js';
-
-/**
- * Environment interface shared by the Worker and the Container Durable Object.
- * Secrets are set via `wrangler secret put …` and never bundled.
- */
-interface Env {
-  BRAVE_SEARCH_CONTAINER: DurableObjectNamespace<BraveSearchContainer>;
-  BRAVE_API_KEY: string;
-  MCP_AUTH_TOKEN: string;
-  INTERNAL_SECRET: string;
-}
 
 /**
  * Brave Search MCP Container configuration.
  * Runs the MCP HTTP server on port 8080.
  *
- * `envVars` is populated in the constructor so secrets are re-applied every time
- * the container starts (cold start, post-sleep restart, redeploy). Setting them
- * here rather than in `startAndWaitForPorts({ startOptions: { envVars } })` is the
- * documented pattern: per-request startOptions are a no-op against an already-warm
- * container, which would silently leave a stale process.env in place.
- *
- * Transport/port/host are configured via Dockerfile.cloudflare ENV defaults:
+ * Transport, port, and host are configured via Dockerfile.cloudflare ENV defaults:
  *   BRAVE_MCP_TRANSPORT=http, BRAVE_MCP_PORT=8080, BRAVE_MCP_HOST=0.0.0.0
  */
-export class BraveSearchContainer extends Container<Env> {
+export class BraveSearchContainer extends Container {
   defaultPort = 8080;
-  sleepAfter = '10m';
 
-  constructor(ctx: DurableObjectState, env: Env) {
-    super(ctx, env);
-    this.envVars = {
-      BRAVE_API_KEY: env.BRAVE_API_KEY ?? '',
-      INTERNAL_SECRET: env.INTERNAL_SECRET ?? '',
-    };
-  }
+  // Keep container alive for 10 minutes after last activity
+  sleepAfter = '10m';
 
   override onStart() {
     console.log('Brave Search MCP Container started');
@@ -58,6 +29,16 @@ export class BraveSearchContainer extends Container<Env> {
   override onStop() {
     console.log('Brave Search MCP Container stopped');
   }
+}
+
+/**
+ * Environment interface for the Worker.
+ * Secrets are set via `wrangler secret put …` and never bundled.
+ */
+interface Env {
+  BRAVE_SEARCH_CONTAINER: DurableObjectNamespace<BraveSearchContainer>;
+  BRAVE_API_KEY: string;
+  MCP_AUTH_TOKEN: string;
 }
 
 type Route = { rewriteTo: string; requireAuth: boolean };
@@ -69,10 +50,6 @@ const ROUTES: Record<string, Route> = {
   '/internal/mcp': { rewriteTo: '/mcp', requireAuth: false },
 };
 
-// Must match wrangler.jsonc containers[].max_instances so getRandom can spread
-// load across every provisioned container.
-const CONTAINER_FANOUT = 2;
-
 const jsonResponse = (
   status: number,
   body: Record<string, unknown>,
@@ -82,20 +59,6 @@ const jsonResponse = (
     status,
     headers: { 'Content-Type': 'application/json', ...(extraHeaders ?? {}) },
   });
-
-const generateRequestId = (request: Request): string =>
-  request.headers.get('cf-ray') ?? crypto.randomUUID();
-
-const backendUnavailable = (requestId: string): Response =>
-  jsonResponse(503, {
-    error: 'Service Unavailable',
-    message: 'Backend temporarily unavailable',
-    requestId,
-  });
-
-const logEvent = (event: string, ctx: Record<string, unknown>): void => {
-  console.error(JSON.stringify({ event, ...ctx }));
-};
 
 export default {
   async fetch(request: Request, env: Env, _ctx: ExecutionContext): Promise<Response> {
@@ -110,8 +73,9 @@ export default {
     }
 
     // Authenticate before any config-state check so unauthenticated probes on the
-    // public surface cannot distinguish "secret missing" from "auth required". A
-    // missing `MCP_AUTH_TOKEN` is treated as a 401, not a configuration error.
+    // public surface cannot distinguish "secret missing" from "auth required".
+    // A missing `MCP_AUTH_TOKEN` is treated as an auth failure (401), not a
+    // configuration error, to keep deployment state opaque to public callers.
     if (route.requireAuth) {
       if (!env.MCP_AUTH_TOKEN || !(await verifyBearer(request, env.MCP_AUTH_TOKEN))) {
         return jsonResponse(
@@ -122,49 +86,44 @@ export default {
       }
     }
 
-    const requestId = generateRequestId(request);
-
-    // Config-state errors collapse into the same generic 503 used for backend
-    // failures so unauthenticated callers on auth-free paths (e.g. /brave/ping)
-    // cannot distinguish "secret missing" from "backend down". Operators see the
-    // specific cause via console.error.
     if (!env.BRAVE_API_KEY) {
-      logEvent('config_missing', { requestId, secret: 'BRAVE_API_KEY' });
-      return backendUnavailable(requestId);
+      // Return the same generic 503 used for container startup failures so
+      // unauthenticated callers on auth-free paths (e.g. /brave/ping) cannot
+      // distinguish "secret missing" from "backend down". Operators see the
+      // specific cause via console.error.
+      console.error('Configuration Error: BRAVE_API_KEY is not configured');
+      return jsonResponse(503, {
+        error: 'Service Unavailable',
+        message: 'Backend temporarily unavailable',
+      });
     }
 
-    if (!env.INTERNAL_SECRET) {
-      logEvent('config_missing', { requestId, secret: 'INTERNAL_SECRET' });
-      return backendUnavailable(requestId);
-    }
-
-    // Rewrite the path before forwarding so the containerized Express app (which
-    // only serves /mcp and /ping) keeps working unchanged. Strip the public
-    // Authorization header so it does not reach the container, and inject the
-    // internal secret that the container will require on /mcp.
+    // Rewrite the path before forwarding so the containerized Express app (which only
+    // serves /mcp and /ping) keeps working unchanged.
     url.pathname = route.rewriteTo;
     const forwarded = new Request(url.toString(), request);
-    forwarded.headers.delete('authorization');
-    forwarded.headers.set('x-internal-secret', env.INTERNAL_SECRET);
 
-    // Round-robin across the provisioned container instances; Brave Search calls
-    // are stateless so any container can serve any request.
-    const container = await getRandom(env.BRAVE_SEARCH_CONTAINER, CONTAINER_FANOUT);
+    const container = getContainer(env.BRAVE_SEARCH_CONTAINER, 'default');
 
     try {
-      await container.startAndWaitForPorts();
-    } catch (err) {
-      const detail = err instanceof Error ? err.message : 'Unknown error';
-      logEvent('container_start_failed', { requestId, path: url.pathname, error: detail });
-      return backendUnavailable(requestId);
-    }
+      await container.startAndWaitForPorts({
+        startOptions: {
+          envVars: {
+            BRAVE_API_KEY: env.BRAVE_API_KEY,
+          },
+        },
+      });
 
-    try {
-      return await container.fetch(forwarded);
+      return container.fetch(forwarded);
     } catch (err) {
+      // Log the underlying cause for operators; return a generic message so
+      // backend infrastructure detail never leaks to the public surface.
       const detail = err instanceof Error ? err.message : 'Unknown error';
-      logEvent('container_fetch_failed', { requestId, path: url.pathname, error: detail });
-      return backendUnavailable(requestId);
+      console.error('Container startup failed:', detail);
+      return jsonResponse(503, {
+        error: 'Service Unavailable',
+        message: 'Backend temporarily unavailable',
+      });
     }
   },
 };


### PR DESCRIPTION
## Summary
Undoes the Worker->Container INTERNAL_SECRET defense-in-depth layer (and its supporting container fan-out / structured logging helpers) introduced in #18, while keeping #20's Node-side opt-in bearer auth and DNS-rebinding guard. Docs aligned with the simplified worker.

## Related
- Reverts the worker portion of #18 (afb77a4)
- Keeps #20 (bb316ed) intact

## Updates
| Item | From | To | Notes |
| --- | --- | --- | --- |
| `src/worker.ts` | PR #18 hardened version with INTERNAL_SECRET + getRandom + structured logEvent | Simplified to a single `getContainer('default')` path; generic 503 with `{ error, message }` | Container quota relies on edge `MCP_AUTH_TOKEN` (still in place) and #20's standalone HTTP-side bearer when the container is reached directly. |
| `src/protocols/http.ts` | `requireInternalSecret` + `transport.onclose` Map eviction | Both removed; #20's `bearerAuth` + `dnsRebindingGuard` mounts preserved | Stateful session cleanup falls back to SDK lifecycle. Stateless (AgentCore) is unaffected. |
| `CLAUDE.md`, `README.md` | INTERNAL_SECRET docs + CONTAINER_FANOUT gotcha + stale upstream defaults | INTERNAL_SECRET removed; defaults corrected to match `src/config.ts`; HTTP entry clarified | Doc churn on top of the code revert. |

## Details
### Revert worker INTERNAL_SECRET defense-in-depth from #18
- Design: edge auth at `/brave/mcp` (Bearer `MCP_AUTH_TOKEN`) is sufficient for the single-tenant Brave proxy. The container-side `x-internal-secret` check added in #18 was defense-in-depth against a misconfigured Workers route exposing `/internal/*`; that risk is also mitigated by `workers_dev: false` and the documented \"only `/brave/*` has a public route\" invariant.
- Implementation notes: code is intentionally restored to the #17 (9755d2c) shape for the worker. `verifyBearer` (SHA-256 + indexOf parser from #17) and the route table from #16 stay.
- Reviewer focus: confirm no public path inadvertently exposes the container; confirm `/internal/mcp` is still service-binding-only.

### Doc alignment with simplified code
- Removed every INTERNAL_SECRET / CONTAINER_FANOUT reference from CLAUDE.md and README.md.
- Corrected long-standing upstream-README defaults disagreeing with \`src/config.ts\`: port \`8080\` (not \`8000\`), stateless default \`false\` (not \`true\`), no \`inspector:stdio\` script (replaced with \`inspector:http\`).
- Tightened the CLAUDE.md HTTP entry description.

## Testing
- \`npm run lint\` -- 0 errors, 8 pre-existing upstream warnings (tolerated per CLAUDE.md).
- Manual: no UI; \`npm run cf:dev\` smoke test recommended on the deployer side.

## Screenshots / Notes
- Not applicable.

## Breaking changes
- Cloudflare deployments that have set \`INTERNAL_SECRET\` will see it become a no-op; the secret can be removed via \`wrangler secret delete INTERNAL_SECRET\` after merge.
- Stateful (\`BRAVE_MCP_STATELESS=false\`) HTTP deployments lose the unbounded-session-Map fix from #18; long-lived containers in stateful mode should switch to stateless or be restarted periodically.

## Risks and rollout
- Risk: a misconfigured Workers route accidentally exposing \`/internal/*\` would now reach the container without the second-layer header check. Mitigation: \`workers_dev: false\` plus the documented \"only \`/brave/*\` has a public route\" invariant.
- Risk: stateful HTTP sessions can accumulate. Mitigation: default deployments are stateless; revisit if a stateful production deployment emerges.

## Checklist
- [ ] Tests added/updated if needed (no test framework configured)
- [x] Docs updated (CLAUDE.md + README.md aligned in this PR)
- [x] Backward compatibility considered (see Breaking changes)
- [x] Rollout/monitoring considerations noted